### PR TITLE
Complete singular PATCH test and functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,5 +96,17 @@ app.delete('/api/v1/palettes/:id', async (request, response) => {
   }
 })
 
+app.patch('/api/v1/palettes/:id', async (request, response) => {
+  const newPaletteInfo = request.body;
+  const palette = await database('palettes').where('id', request.params.id).select();
+
+  if (palette.length) {
+    const selectedPalette = await database('palettes').where('id', request.params.id).update('name', newPaletteInfo.name)
+    return response.status(200).json()
+  } else {
+    return response.status(404).json({error: 'Palette not found'})
+  }
+})
+
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -187,4 +187,43 @@ describe('Server', () => {
       expect(res.status).toBe(404)
     })
   })
+
+  describe('PATCH /api/v1/palettes/:id', () => {
+    it('should update a given palette name', async () => {
+      const expectedPalette = await database('palettes').first()
+      const id = expectedPalette.id
+      const newPalette = {name: 'Edited Palette'}
+
+      const res = await request(app)
+        .patch(`/api/v1/palettes/${id}`)
+        .send(newPalette)
+
+      expect(res.status).toBe(200)
+      expect(newPalette.name).toBe("Edited Palette")    
+    })
+
+    it('should update a given palette color', async () => {
+
+    })
+  })
+  describe('PATCH /api/v1/folders/:id', () => {
+    it('should update a given folder name', async () => {
+
+    })
+  })
+
 })
+
+// const expectedFolder = await database('folders').first()
+// const id = expectedFolder.id
+// const newPalette = { name: 'Shady Grove', c1: "#050505", c2: "#004FFF", c3: "#31AFD4", c4: "#902D41", c5: "#FFOO7F", folder_id: id}
+
+// const res = await request(app)
+//   .post(`/api/v1/folders/${id}/palettes`)
+//   .send(newPalette)
+
+// const palettes = await database('palettes').where('id', res.body.id).select()
+// const palette = palettes[0]
+
+// expect(res.status).toBe(201)
+// expect(palette.name).toEqual(newPalette.name)


### PR DESCRIPTION
Co-authored-by: Alyssa Lundgren <lundgrea@gmail.com>

#### What's this PR do?
This commit applies the PATCH test and initial functionality (ability to replace palette name)
#### Where should the reviewer start?
The reviews should start in app.js and app.test.js
#### How should this be manually tested?
This can be tested either in Postman or in the browser URL itself (localhost:3001)
#### Any background context you want to provide?
N/A
#### What are the relevant tickets?
"PATCH request (palette)"
#### Screenshots (if appropriate)
#### Questions: